### PR TITLE
fix error caused by supplied arguments

### DIFF
--- a/GettingStartedWithCreateJS/index.html
+++ b/GettingStartedWithCreateJS/index.html
@@ -15,7 +15,7 @@
             queue = new createjs.LoadQueue(false);
             queue.installPlugin(createjs.Sound);
             queue.addEventListener("complete", handleComplete);
-            queue.loadManifest([{id:"daisy", src:"assets/daisy.png"}, {id:"sound", src:"assets/pop.mp3"}]);
+            queue.loadManifest({id:"daisy", src:"assets/daisy.png"}, {id:"sound", src:"assets/pop.mp3"});
 
         }
 


### PR DESCRIPTION
loadManifest() handles multiple object parameters instead of array of object

fixed TypeError: undefined is not a function
